### PR TITLE
Upgrade to scala 2.12.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "lib-reference-scala"
 
 organization := "io.flow"
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.2"
 
-crossScalaVersions := Seq("2.11.11", "2.10.6")
+crossScalaVersions := Seq("2.12.2", "2.11.11", "2.10.6")
 
 lazy val root = project
   .in(file("."))

--- a/src/main/scala/io/flow/reference/Countries.scala
+++ b/src/main/scala/io/flow/reference/Countries.scala
@@ -75,7 +75,7 @@ object Countries extends Validation[Country] {
         }
 
         case Some(c) => {
-          countries += c
+          countries.append(c)
         }
       }
     }


### PR DESCRIPTION
- so we can cross build gilt libraries for scala 2.12