### PR TITLE
Generate reference data

### DIFF
--- a/release.go
+++ b/release.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"github.com/flowcommerce/tools/executor"
 	"github.com/flowcommerce/tools/scala_library"
 )
 
 func main() {
+	executor := executor.Create("lib-reference-scala-json")
+	executor = executor.Add("go get -u github.com/flowcommerce/json-reference/common")
+	executor = executor.Add("go run script/generate.go")
+	executor.Run()
+
 	scala_library.Run()
 }


### PR DESCRIPTION
adds back data generation that was lost in this commit:
https://github.com/flowcommerce/lib-reference-scala/commit/35d67c2f5e4bbcdd6c251de0de4c0ebbc5b7a5af#diff-15036d5e0876436b1832c7721c9c7afd