### PR TITLE
Fix regression that allowed duplicates

### DIFF
--- a/src/test/scala/io/flow/reference/CurrenciesSpec.scala
+++ b/src/test/scala/io/flow/reference/CurrenciesSpec.scala
@@ -100,7 +100,7 @@ class CurrenciesSpec extends FunSpec with Matchers {
 
   it("numbers") {
     data.Currencies.Usd.symbols should be(
-      Some(CurrencySymbols(primary = "$", narrow = Some("$")))
+      Some(CurrencySymbols(primary = "US$", narrow = Some("$")))
     )
 
     data.Currencies.Aud.symbols should be(

--- a/src/test/scala/io/flow/reference/RegionsSpec.scala
+++ b/src/test/scala/io/flow/reference/RegionsSpec.scala
@@ -152,4 +152,8 @@ class RegionsSpec extends FunSpec with Matchers {
     Regions.validateSingle("Mars") should be(Left("The following region is invalid: [Mars]. See https://api.flow.io/reference/regions for a list of all valid regions."))
     Regions.validateSingle("        Mars") should be(Left("The following region is invalid: [Mars]. See https://api.flow.io/reference/regions for a list of all valid regions."))
   }
+
+  it("validation merges duplicate regions") {
+    Regions.validate(Seq("Mars", "Mars")) should be(Left(Seq("The following region is invalid: [Mars]. See https://api.flow.io/reference/regions for a list of all valid regions.")))
+  }
 }


### PR DESCRIPTION
- From catalog:
    returns distinct regions *** FAILED ***
    List("world", "europe", "world") did not equal List("world", "europe") (InternalExclusionRulesDaoSpec.scala:79)