### PR TITLE
Fix release script to commit regenerated models

### DIFF
--- a/release.go
+++ b/release.go
@@ -9,6 +9,9 @@ func main() {
 	executor := executor.Create("lib-reference-scala-json")
 	executor = executor.Add("go get -u github.com/flowcommerce/json-reference/common")
 	executor = executor.Add("go run script/generate.go")
+	executor = executor.Add("sbt test")
+	executor = executor.Add("git commit -am 'autocommit: Regenerate models'")
+
 	executor.Run()
 
 	scala_library.Run()


### PR DESCRIPTION
Currently, running `release.go` effectively [just increments the version number](https://github.com/flowcommerce/lib-reference-scala/commit/68dab46630935ca3acdc327cccf591481c9be5b6). This PR fixes the issue by adding regenerated models so they're included in the release.