### PR TITLE
Revert "CORE-587: Long substring should be able to find value in reference cache"

### DIFF
--- a/src/main/scala/io/flow/reference/Validation.scala
+++ b/src/main/scala/io/flow/reference/Validation.scala
@@ -31,23 +31,7 @@ trait Validation[T] {
   def urlKey: String = plural
 
   def find(q: String): Option[T] = {
-    cache.get(q.toLowerCase.trim) match {
-      case Some(value) => Some(value)
-      case None => findBySubstring(q)
-    }
-  }
-
-  /**
-   * Attempts to find a key using a substring
-   */
-  def findBySubstring(q: String): Option[T] = {
-    if (q.length > 10) {
-      cache.keys.toSeq.find(_.startsWith(q)).flatMap { key =>
-        cache.get(key)
-      }
-    } else {
-      None
-    }
+    cache.get(q.toLowerCase.trim)
   }
 
   /** Attempts to find a single object; if it cannot be found, validates it to return an error message. */

--- a/src/test/scala/io/flow/reference/CountriesSpec.scala
+++ b/src/test/scala/io/flow/reference/CountriesSpec.scala
@@ -79,7 +79,7 @@ class CountriesSpec extends AnyFunSpec with Matchers {
   }
 
   it("find") {
-    Seq("usa", "USA", " usa ", "us", "US", "united states of america", "united states").foreach { name =>
+    Seq("usa", "USA", " usa ", "us", "US", "united states of america").foreach { name =>
       Countries.find(name).getOrElse {
         sys.error(s"$name missing")
       }


### PR DESCRIPTION
Reverts flowcommerce/lib-reference-scala#98