### PR TITLE
FIN-1774: Use carrier constants in carrier services

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ for all of the types of reference data:
 
   [Scala Tests](/src/test/scala/io/flow/reference/)
 
-## Updating to latest models
+## Invoking the code generator
 
 ```
-    git checkout -b <release_branch>
-    go run release.go
-    git pull-request
+    go run script/generate.go
+    sbt compile
 ```

--- a/script/generate.go
+++ b/script/generate.go
@@ -92,9 +92,10 @@ func processCarriers() {
 func processCarrierServices() {
 	instances := []Instance{}
 	for _, cs := range common.CarrierServices() {
+		carrierId := scalaName(formatLocaleIdForName(cs.Carrier.Id))
 		instances = append(instances, Instance{
 			Name:  strings.Replace(cs.Id, "-", "_", -1),
-			Value: fmt.Sprintf("CarrierService(id = \"%s\", name = \"%s\", carrier = io.flow.reference.v0.models.Carrier(id = \"%s\", name = \"%s\", trackingUrl = \"%s\"))", cs.Id, cs.Name, cs.Carrier.Id, cs.Carrier.Name, cs.Carrier.TrackingUrl),
+			Value: fmt.Sprintf("CarrierService(id = \"%s\", name = \"%s\", carrier = io.flow.reference.data.Carriers.%s)", cs.Id, cs.Name, carrierId),
 		})
 	}
 

--- a/script/generate.go
+++ b/script/generate.go
@@ -92,7 +92,7 @@ func processCarriers() {
 func processCarrierServices() {
 	instances := []Instance{}
 	for _, cs := range common.CarrierServices() {
-		carrierId := scalaName(formatLocaleIdForName(cs.Carrier.Id))
+		carrierId := scalaName(formatIdForName(cs.Carrier.Id))
 		instances = append(instances, Instance{
 			Name:  strings.Replace(cs.Id, "-", "_", -1),
 			Value: fmt.Sprintf("CarrierService(id = \"%s\", name = \"%s\", carrier = io.flow.reference.data.Carriers.%s)", cs.Id, cs.Name, carrierId),
@@ -215,7 +215,7 @@ func processLocales() {
 	instances := []Instance{}
 	for _, l := range common.Locales() {
 		instances = append(instances, Instance{
-			Name:  formatLocaleIdForName(l.Id),
+			Name:  formatIdForName(l.Id),
 			Value: fmt.Sprintf("Locale(id = \"%s\", name = \"%s\", country = \"%s\", language = \"%s\", numbers = LocaleNumbers(decimal = \"%s\", group = \"%s\"))", l.Id, l.Name, l.Country, l.Language, l.Numbers.Decimal, l.Numbers.Group),
 		})
 	}
@@ -335,7 +335,7 @@ func scalaName(name string) string {
 	return s
 }
 
-func formatLocaleIdForName(id string) string {
+func formatIdForName(id string) string {
 	return strings.Replace(id, "-", "_", -1)
 }
 

--- a/src/main/scala/io/flow/reference/data/CarrierServices.scala
+++ b/src/main/scala/io/flow/reference/data/CarrierServices.scala
@@ -7,651 +7,380 @@ object CarrierServices {
   val AsendiaEPaqSelect: CarrierService = CarrierService(
     id = "asendia-e-paq-select",
     name = "e-Paq Select",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "asendia", name = "Asendia", trackingUrl = "https://track.aftership.com/asendia/"),
+    carrier = io.flow.reference.data.Carriers.Asendia,
   )
-  val AsendiaExpress: CarrierService = CarrierService(
-    id = "asendia-express",
-    name = "Express",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "asendia", name = "Asendia", trackingUrl = "https://track.aftership.com/asendia/"),
-  )
-  val AsendiaStandard: CarrierService = CarrierService(
-    id = "asendia-standard",
-    name = "Standard",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "asendia", name = "Asendia", trackingUrl = "https://track.aftership.com/asendia/"),
-  )
+  val AsendiaExpress: CarrierService =
+    CarrierService(id = "asendia-express", name = "Express", carrier = io.flow.reference.data.Carriers.Asendia)
+  val AsendiaStandard: CarrierService =
+    CarrierService(id = "asendia-standard", name = "Standard", carrier = io.flow.reference.data.Carriers.Asendia)
   val CanadaPostExpeditedParcel: CarrierService = CarrierService(
     id = "canada-post-expedited-parcel",
     name = "Expedited Parcel",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "canada-post", name = "Canada Post", trackingUrl = "https://track.aftership.com/canada-post/"),
+    carrier = io.flow.reference.data.Carriers.CanadaPost,
   )
-  val CanadaPostPriority: CarrierService = CarrierService(
-    id = "canada-post-priority",
-    name = "Priority",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "canada-post", name = "Canada Post", trackingUrl = "https://track.aftership.com/canada-post/"),
-  )
+  val CanadaPostPriority: CarrierService =
+    CarrierService(id = "canada-post-priority", name = "Priority", carrier = io.flow.reference.data.Carriers.CanadaPost)
   val CanadaPostRegularParcel: CarrierService = CarrierService(
     id = "canada-post-regular-parcel",
     name = "Regular Parcel",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "canada-post", name = "Canada Post", trackingUrl = "https://track.aftership.com/canada-post/"),
+    carrier = io.flow.reference.data.Carriers.CanadaPost,
   )
   val CanadaPostXpresspost: CarrierService = CarrierService(
     id = "canada-post-xpresspost",
     name = "Xpresspost",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "canada-post", name = "Canada Post", trackingUrl = "https://track.aftership.com/canada-post/"),
+    carrier = io.flow.reference.data.Carriers.CanadaPost,
   )
   val ChronopostChronoClassic: CarrierService = CarrierService(
     id = "chronopost-chrono-classic",
     name = "Classic",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "chronopost",
-      name = "Chronopost",
-      trackingUrl = "https://www.chronopost.fr/en/chrono_suivi_search?listeNumerosLT=",
-    ),
+    carrier = io.flow.reference.data.Carriers.Chronopost,
   )
   val ChronopostChronoExpress: CarrierService = CarrierService(
     id = "chronopost-chrono-express",
     name = "Express",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "chronopost",
-      name = "Chronopost",
-      trackingUrl = "https://www.chronopost.fr/en/chrono_suivi_search?listeNumerosLT=",
-    ),
+    carrier = io.flow.reference.data.Carriers.Chronopost,
   )
   val DeutschePostPacketTrackedPriorityGpt: CarrierService = CarrierService(
     id = "deutsche-post-packet-tracked-priority-gpt",
     name = "Packet Tracked Priority GPT",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "deutsche-post", name = "Deutsche Post", trackingUrl = "https://track.aftership.com/deutsch-post/"),
+    carrier = io.flow.reference.data.Carriers.DeutschePost,
   )
   val DeutschePostUsaDirect: CarrierService = CarrierService(
     id = "deutsche-post-usa-direct",
     name = "USA Direct",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "deutsche-post", name = "Deutsche Post", trackingUrl = "https://track.aftership.com/deutsch-post/"),
+    carrier = io.flow.reference.data.Carriers.DeutschePost,
   )
   val DhlEcommerceStandard: CarrierService = CarrierService(
     id = "dhl-ecommerce-standard",
     name = "Standard",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl-ecommerce",
-      name = "DHL Ecommerce",
-      trackingUrl = "https://webtrack.dhlglobalmail.com/?trackingnumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.DhlEcommerce,
   )
-  val DhlEconomySelect: CarrierService = CarrierService(
-    id = "dhl-economy-select",
-    name = "Economy Select",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl",
-      name = "DHL Express",
-      trackingUrl = "https://mydhl.express.dhl/us/en/tracking.html#/results?id=",
-    ),
-  )
+  val DhlEconomySelect: CarrierService =
+    CarrierService(id = "dhl-economy-select", name = "Economy Select", carrier = io.flow.reference.data.Carriers.Dhl)
   val DhlExpressDomestic1800: CarrierService = CarrierService(
     id = "dhl-express-domestic-1800",
     name = "Express Domestic 18:00",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl",
-      name = "DHL Express",
-      trackingUrl = "https://mydhl.express.dhl/us/en/tracking.html#/results?id=",
-    ),
+    carrier = io.flow.reference.data.Carriers.Dhl,
   )
   val DhlExpressExportEconomy: CarrierService = CarrierService(
     id = "dhl-express-export-economy",
     name = "Express Export Economy",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl",
-      name = "DHL Express",
-      trackingUrl = "https://mydhl.express.dhl/us/en/tracking.html#/results?id=",
-    ),
+    carrier = io.flow.reference.data.Carriers.Dhl,
   )
   val DhlExpressWorldwide: CarrierService = CarrierService(
     id = "dhl-express-worldwide",
     name = "Express Worldwide",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl",
-      name = "DHL Express",
-      trackingUrl = "https://mydhl.express.dhl/us/en/tracking.html#/results?id=",
-    ),
+    carrier = io.flow.reference.data.Carriers.Dhl,
   )
   val DhlGlobalMailPacketPlus: CarrierService = CarrierService(
     id = "dhl-global-mail-packet-plus",
     name = "Packet Plus",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl-global-mail",
-      name = "DHL Global Mail",
-      trackingUrl = "https://webtrack.dhlglobalmail.com/?trackingnumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.DhlGlobalMail,
   )
   val DhlParcelInternationalDirect: CarrierService = CarrierService(
     id = "dhl-parcel-international-direct",
     name = "International Direct",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl-parcel",
-      name = "DHL Parcel",
-      trackingUrl = "https://webtrack.dhlglobalmail.com/?trackingnumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.DhlParcel,
   )
   val DhlParcelInternationalDirectSmb: CarrierService = CarrierService(
     id = "dhl-parcel-international-direct-smb",
     name = "International Direct SMB",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl-parcel",
-      name = "DHL Parcel",
-      trackingUrl = "https://webtrack.dhlglobalmail.com/?trackingnumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.DhlParcel,
   )
   val DhlParcelInternationalStandard: CarrierService = CarrierService(
     id = "dhl-parcel-international-standard",
     name = "International Standard",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl-parcel",
-      name = "DHL Parcel",
-      trackingUrl = "https://webtrack.dhlglobalmail.com/?trackingnumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.DhlParcel,
   )
   val DhlParcelInternationalStandardSmb: CarrierService = CarrierService(
     id = "dhl-parcel-international-standard-smb",
     name = "International Standard SMB",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "dhl-parcel",
-      name = "DHL Parcel",
-      trackingUrl = "https://webtrack.dhlglobalmail.com/?trackingnumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.DhlParcel,
   )
   val FedexCrossborderEcommerce: CarrierService = CarrierService(
     id = "fedex-crossborder-ecommerce",
     name = "E-commerce",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderEcommerceLite: CarrierService = CarrierService(
     id = "fedex-crossborder-ecommerce-lite",
     name = "E-commerce Lite",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicExpressPriority: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-express-priority",
     name = "FIC Express Priority",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicLimitedTracked: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-limited-tracked",
     name = "FIC Limited Tracked",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicLimitedTrackedPlus: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-limited-tracked-plus",
     name = "FIC Limited Tracked Plus",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicPudoService: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-pudo-service",
     name = "FIC PUDO Service",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicTrackedUsaPriority: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-tracked-usa-priority",
     name = "FIC Tracked USA Priority",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicTrackedWorldwide: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-tracked-worldwide",
     name = "FIC Tracked Worldwide",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderFicUntrackedUk: CarrierService = CarrierService(
     id = "fedex-crossborder-fic-untracked-uk",
     name = "FIC Untracked UK",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderRoyalMailTracked24: CarrierService = CarrierService(
     id = "fedex-crossborder-royal-mail-tracked-24",
     name = "Royal Mail Tracked 24",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderRoyalMailTracked48: CarrierService = CarrierService(
     id = "fedex-crossborder-royal-mail-tracked-48",
     name = "Royal Mail Tracked 48",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderUk24Hours: CarrierService = CarrierService(
     id = "fedex-crossborder-uk-24-hours",
     name = "UK 24 Hours",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderUk48Hours: CarrierService = CarrierService(
     id = "fedex-crossborder-uk-48-hours",
     name = "UK 48 hours",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
   val FedexCrossborderYodel72HourPacket: CarrierService = CarrierService(
     id = "fedex-crossborder-yodel-72-hour-packet",
     name = "Yodel 72 Hour Packet",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "fedex-crossborder",
-      name = "FedEx Crossborder",
-      trackingUrl = "https://www.trackmytrakpak.com/?MyTrakPakNumber=",
-    ),
+    carrier = io.flow.reference.data.Carriers.FedexCrossborder,
   )
-  val FedexGround: CarrierService = CarrierService(
-    id = "fedex-ground",
-    name = "Ground",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "fedex", name = "FedEx", trackingUrl = "https://www.fedex.com/apps/fedextrack/?tracknumbers="),
-  )
+  val FedexGround: CarrierService =
+    CarrierService(id = "fedex-ground", name = "Ground", carrier = io.flow.reference.data.Carriers.Fedex)
   val FedexInternationalEconomy: CarrierService = CarrierService(
     id = "fedex-international-economy",
     name = "International Economy",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "fedex", name = "FedEx", trackingUrl = "https://www.fedex.com/apps/fedextrack/?tracknumbers="),
+    carrier = io.flow.reference.data.Carriers.Fedex,
   )
   val FedexInternationalPriority: CarrierService = CarrierService(
     id = "fedex-international-priority",
     name = "International Priority",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "fedex", name = "FedEx", trackingUrl = "https://www.fedex.com/apps/fedextrack/?tracknumbers="),
+    carrier = io.flow.reference.data.Carriers.Fedex,
   )
   val FedexInternationalStandard: CarrierService = CarrierService(
     id = "fedex-international-standard",
     name = "International Standard",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "fedex", name = "FedEx", trackingUrl = "https://www.fedex.com/apps/fedextrack/?tracknumbers="),
+    carrier = io.flow.reference.data.Carriers.Fedex,
   )
-  val FedexOvernight: CarrierService = CarrierService(
-    id = "fedex-overnight",
-    name = "Overnight",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "fedex", name = "FedEx", trackingUrl = "https://www.fedex.com/apps/fedextrack/?tracknumbers="),
-  )
+  val FedexOvernight: CarrierService =
+    CarrierService(id = "fedex-overnight", name = "Overnight", carrier = io.flow.reference.data.Carriers.Fedex)
   val IlgEconomyUntracked: CarrierService = CarrierService(
     id = "ilg-economy-untracked",
     name = "Economy Untracked",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "ilg", name = "ILG", trackingUrl = "https://www.ilguk.com/track-trace/"),
+    carrier = io.flow.reference.data.Carriers.Ilg,
   )
   val IlgEuropeanSinglePack: CarrierService = CarrierService(
     id = "ilg-european-single-pack",
     name = "European Single Pack",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "ilg", name = "ILG", trackingUrl = "https://www.ilguk.com/track-trace/"),
+    carrier = io.flow.reference.data.Carriers.Ilg,
   )
-  val IlgExpressTracked: CarrierService = CarrierService(
-    id = "ilg-express-tracked",
-    name = "Express Tracked",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "ilg", name = "ILG", trackingUrl = "https://www.ilguk.com/track-trace/"),
-  )
-  val IlgGlobalCourier: CarrierService = CarrierService(
-    id = "ilg-global-courier",
-    name = "Global Courier",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "ilg", name = "ILG", trackingUrl = "https://www.ilguk.com/track-trace/"),
-  )
+  val IlgExpressTracked: CarrierService =
+    CarrierService(id = "ilg-express-tracked", name = "Express Tracked", carrier = io.flow.reference.data.Carriers.Ilg)
+  val IlgGlobalCourier: CarrierService =
+    CarrierService(id = "ilg-global-courier", name = "Global Courier", carrier = io.flow.reference.data.Carriers.Ilg)
   val IlgInternationalCourier: CarrierService = CarrierService(
     id = "ilg-international-courier",
     name = "International Courier",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "ilg", name = "ILG", trackingUrl = "https://www.ilguk.com/track-trace/"),
+    carrier = io.flow.reference.data.Carriers.Ilg,
   )
   val IlgStandardTracked: CarrierService = CarrierService(
     id = "ilg-standard-tracked",
     name = "Standard Tracked",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "ilg", name = "ILG", trackingUrl = "https://www.ilguk.com/track-trace/"),
+    carrier = io.flow.reference.data.Carriers.Ilg,
   )
-  val LaPosteColissimo: CarrierService = CarrierService(
-    id = "la-poste-colissimo",
-    name = "Colissimo",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "la-poste",
-      name = "La Poste",
-      trackingUrl = "https://www.laposte.fr/particulier/outils/en/track-a-parcel?code=",
-    ),
-  )
-  val LandmarkGlobal: CarrierService = CarrierService(
-    id = "landmark-global",
-    name = "Global",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "landmark", name = "Landmark", trackingUrl = "https://track.landmarkglobal.com/?trck="),
-  )
-  val MalcaAmitArmored: CarrierService = CarrierService(
-    id = "malca-amit-armored",
-    name = "Armored",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "malca-amit", name = "Malca Amit", trackingUrl = "https://tracking.malca-amit.com/?t="),
-  )
-  val MalcaAmitExpress: CarrierService = CarrierService(
-    id = "malca-amit-express",
-    name = "Express",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "malca-amit", name = "Malca Amit", trackingUrl = "https://tracking.malca-amit.com/?t="),
-  )
+  val LaPosteColissimo: CarrierService =
+    CarrierService(id = "la-poste-colissimo", name = "Colissimo", carrier = io.flow.reference.data.Carriers.LaPoste)
+  val LandmarkGlobal: CarrierService =
+    CarrierService(id = "landmark-global", name = "Global", carrier = io.flow.reference.data.Carriers.Landmark)
+  val MalcaAmitArmored: CarrierService =
+    CarrierService(id = "malca-amit-armored", name = "Armored", carrier = io.flow.reference.data.Carriers.MalcaAmit)
+  val MalcaAmitExpress: CarrierService =
+    CarrierService(id = "malca-amit-express", name = "Express", carrier = io.flow.reference.data.Carriers.MalcaAmit)
   val OcsWorldwideInternationalStandardDelivery: CarrierService = CarrierService(
     id = "ocs-worldwide-international-standard-delivery",
     name = "International Standard Delivery",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "ocs-worldwide",
-      name = "OCS Worldwide",
-      trackingUrl = "https://www.ocsworldwide.co.uk/Tracking.aspx?cwb=",
-    ),
+    carrier = io.flow.reference.data.Carriers.OcsWorldwide,
   )
-  val OtherFreight: CarrierService = CarrierService(
-    id = "other-freight",
-    name = "Freight",
-    carrier = io.flow.reference.v0.models.Carrier(id = "other", name = "Other", trackingUrl = "https://track.flow.io/"),
-  )
-  val OtherLtl: CarrierService = CarrierService(
-    id = "other-ltl",
-    name = "Less Than Truckload",
-    carrier = io.flow.reference.v0.models.Carrier(id = "other", name = "Other", trackingUrl = "https://track.flow.io/"),
-  )
-  val OtherPostal: CarrierService = CarrierService(
-    id = "other-postal",
-    name = "Postal",
-    carrier = io.flow.reference.v0.models.Carrier(id = "other", name = "Other", trackingUrl = "https://track.flow.io/"),
-  )
+  val OtherFreight: CarrierService =
+    CarrierService(id = "other-freight", name = "Freight", carrier = io.flow.reference.data.Carriers.Other)
+  val OtherLtl: CarrierService =
+    CarrierService(id = "other-ltl", name = "Less Than Truckload", carrier = io.flow.reference.data.Carriers.Other)
+  val OtherPostal: CarrierService =
+    CarrierService(id = "other-postal", name = "Postal", carrier = io.flow.reference.data.Carriers.Other)
   val RrdonnelleyInternationalIpa: CarrierService = CarrierService(
     id = "rrdonnelley-international-ipa",
     name = "International IPA",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "rrdonnelley", name = "RR Donnelley", trackingUrl = "https://track.aftership.com/rrdonnelley/"),
+    carrier = io.flow.reference.data.Carriers.Rrdonnelley,
   )
   val RrdonnelleyInternationalPpdc: CarrierService = CarrierService(
     id = "rrdonnelley-international-ppdc",
     name = "International PPDC",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "rrdonnelley", name = "RR Donnelley", trackingUrl = "https://track.aftership.com/rrdonnelley/"),
+    carrier = io.flow.reference.data.Carriers.Rrdonnelley,
   )
   val SfExpressEconomyExpressParcel: CarrierService = CarrierService(
     id = "sf-express-economy-express-parcel",
     name = "Economy Express Parcel",
-    carrier = io.flow.reference.v0.models.Carrier(
-      id = "sf-express",
-      name = "SF Express",
-      trackingUrl = "http://www.sf-express.com/us/en/dynamic_function/waybill/#search/bill-number/",
-    ),
+    carrier = io.flow.reference.data.Carriers.SfExpress,
   )
-  val Ups2ndDayAir: CarrierService = CarrierService(
-    id = "ups-2nd-day-air",
-    name = "2nd Day Air",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
-  val Ups2ndDayAirAm: CarrierService = CarrierService(
-    id = "ups-2nd-day-air-am",
-    name = "2nd Day Air AM",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
-  val Ups3DaySelect: CarrierService = CarrierService(
-    id = "ups-3-day-select",
-    name = "3 Day Select",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val Ups2ndDayAir: CarrierService =
+    CarrierService(id = "ups-2nd-day-air", name = "2nd Day Air", carrier = io.flow.reference.data.Carriers.Ups)
+  val Ups2ndDayAirAm: CarrierService =
+    CarrierService(id = "ups-2nd-day-air-am", name = "2nd Day Air AM", carrier = io.flow.reference.data.Carriers.Ups)
+  val Ups3DaySelect: CarrierService =
+    CarrierService(id = "ups-3-day-select", name = "3 Day Select", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsAccessPointEconomy: CarrierService = CarrierService(
     id = "ups-access-point-economy",
     name = "Access Point Economy",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsEconomyMailInnovations: CarrierService = CarrierService(
     id = "ups-economy-mail-innovations",
     name = "Economy Mail Innovations",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsExpedited: CarrierService = CarrierService(
-    id = "ups-expedited",
-    name = "Expedited",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsExpedited: CarrierService =
+    CarrierService(id = "ups-expedited", name = "Expedited", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsExpeditedMaiiInnovations: CarrierService = CarrierService(
     id = "ups-expedited-maii-innovations",
     name = "Expedited MaiI Innovations",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsExpress: CarrierService = CarrierService(
-    id = "ups-express",
-    name = "Express",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
-  val UpsExpress1200: CarrierService = CarrierService(
-    id = "ups-express-1200",
-    name = "Express 1200",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsExpress: CarrierService =
+    CarrierService(id = "ups-express", name = "Express", carrier = io.flow.reference.data.Carriers.Ups)
+  val UpsExpress1200: CarrierService =
+    CarrierService(id = "ups-express-1200", name = "Express 1200", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsExpressInternational: CarrierService = CarrierService(
     id = "ups-express-international",
     name = "Express International",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsExpressPlus: CarrierService = CarrierService(
-    id = "ups-express-plus",
-    name = "Express Plus",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
-  val UpsExpressSaver: CarrierService = CarrierService(
-    id = "ups-express-saver",
-    name = "Express Saver",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsExpressPlus: CarrierService =
+    CarrierService(id = "ups-express-plus", name = "Express Plus", carrier = io.flow.reference.data.Carriers.Ups)
+  val UpsExpressSaver: CarrierService =
+    CarrierService(id = "ups-express-saver", name = "Express Saver", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsFirstClassMail: CarrierService = CarrierService(
     id = "ups-first-class-mail",
     name = "First Class Mail",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsGround: CarrierService = CarrierService(
-    id = "ups-ground",
-    name = "Ground",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsGround: CarrierService =
+    CarrierService(id = "ups-ground", name = "Ground", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsInternationalImport: CarrierService = CarrierService(
     id = "ups-international-import",
     name = "International Import",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsMaiiInnovationsReturns: CarrierService = CarrierService(
     id = "ups-maii-innovations-returns",
     name = "MaiI Innovations Returns",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsNextDayAir: CarrierService = CarrierService(
-    id = "ups-next-day-air",
-    name = "Next Day Air",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsNextDayAir: CarrierService =
+    CarrierService(id = "ups-next-day-air", name = "Next Day Air", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsNextDayAirEarly: CarrierService = CarrierService(
     id = "ups-next-day-air-early",
     name = "Next Day Air Early",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsNextDayAirSaver: CarrierService = CarrierService(
     id = "ups-next-day-air-saver",
     name = "Next Day Air Saver",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsPriorityMail: CarrierService = CarrierService(
-    id = "ups-priority-mail",
-    name = "Priority Mail",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsPriorityMail: CarrierService =
+    CarrierService(id = "ups-priority-mail", name = "Priority Mail", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsPriorityMailInnovations: CarrierService = CarrierService(
     id = "ups-priority-mail-innovations",
     name = "Priority Mail Innovations",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsStandard: CarrierService = CarrierService(
-    id = "ups-standard",
-    name = "Standard",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsStandard: CarrierService =
+    CarrierService(id = "ups-standard", name = "Standard", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsStandardInternational: CarrierService = CarrierService(
     id = "ups-standard-international",
     name = "Standard International",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsTodayDedicatedCourier: CarrierService = CarrierService(
     id = "ups-today-dedicated-courier",
     name = "Today Dedicated Courier",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsTodayExpress: CarrierService = CarrierService(
-    id = "ups-today-express",
-    name = "Today Express",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsTodayExpress: CarrierService =
+    CarrierService(id = "ups-today-express", name = "Today Express", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsTodayExpressSaver: CarrierService = CarrierService(
     id = "ups-today-express-saver",
     name = "Today Express Saver",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
-  val UpsTodayIntercity: CarrierService = CarrierService(
-    id = "ups-today-intercity",
-    name = "Today Intercity",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
-  val UpsTodayStandard: CarrierService = CarrierService(
-    id = "ups-today-standard",
-    name = "Today Standard",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
-  )
+  val UpsTodayIntercity: CarrierService =
+    CarrierService(id = "ups-today-intercity", name = "Today Intercity", carrier = io.flow.reference.data.Carriers.Ups)
+  val UpsTodayStandard: CarrierService =
+    CarrierService(id = "ups-today-standard", name = "Today Standard", carrier = io.flow.reference.data.Carriers.Ups)
   val UpsWorldwideEconomy: CarrierService = CarrierService(
     id = "ups-worldwide-economy",
     name = "Worldwide Economy",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsWorldwideEconomyDdu: CarrierService = CarrierService(
     id = "ups-worldwide-economy-ddu",
     name = "Worldwide Economy DDU",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsWorldwideExpedited: CarrierService = CarrierService(
     id = "ups-worldwide-expedited",
     name = "Worldwide Expedited",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsWorldwideExpress: CarrierService = CarrierService(
     id = "ups-worldwide-express",
     name = "Worldwide Express",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsWorldwideExpressFreightMidday: CarrierService = CarrierService(
     id = "ups-worldwide-express-freight-midday",
     name = "Worldwide Express Freight Midday",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsWorldwideExpressFreight: CarrierService = CarrierService(
     id = "ups-worldwide-express-freight.",
     name = "Worldwide Express Freight",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UpsWorldwideExpressPlus: CarrierService = CarrierService(
     id = "ups-worldwide-express-plus",
     name = "Worldwide Express Plus",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "ups", name = "UPS", trackingUrl = "https://www.ups.com/track?loc=en_US&tracknum="),
+    carrier = io.flow.reference.data.Carriers.Ups,
   )
   val UspsPriorityMailInternational: CarrierService = CarrierService(
     id = "usps-priority-mail-international",
     name = "Priority Mail International",
-    carrier =
-      io.flow.reference.v0.models.Carrier(id = "usps", name = "USPS", trackingUrl = "https://track.aftership.com/usps/"),
+    carrier = io.flow.reference.data.Carriers.Usps,
   )
-  val WnDirectStandard: CarrierService = CarrierService(
-    id = "wn-direct-standard",
-    name = "Standard",
-    carrier = io.flow.reference.v0.models
-      .Carrier(id = "wn-direct", name = "WN Direct", trackingUrl = "http://wndirect.com/tracking.php?type=TR&ref="),
-  )
+  val WnDirectStandard: CarrierService =
+    CarrierService(id = "wn-direct-standard", name = "Standard", carrier = io.flow.reference.data.Carriers.WnDirect)
 
   val all: Seq[CarrierService] = Seq(
     AsendiaEPaqSelect,


### PR DESCRIPTION
Changes the code generator for the CarrierService class to reference the Carrier Constant instead of instantiating a new carrier for each service.

Old:
```
  CarrierService(
    carrier = io.flow.reference.v0.models
      .Carrier(id = "asendia", name = "Asendia", trackingUrl = "https://track.aftership.com/asendia/"),
  )
```

New:
```
  CarrierService(
    carrier = io.flow.reference.data.Carriers.Asendia,
  )
```
