### PR TITLE
FDN-3203: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val root = project
     scalafmtOnCompile := true,
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.10.0",
-      "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     ),
     credentials += Credentials(
       "Artifactory Realm",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,9 +10,9 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.60")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")


### PR DESCRIPTION
- io.flow
  - sbt-flow-linter (0.0.59 => 0.0.60)
- org.scalameta
  - sbt-scalafmt (2.5.2 => 2.5.4)
- org.scalatest
  - scalatest (3.2.18 => 3.2.19)
- org.scoverage
  - sbt-scoverage (2.2.2 => 2.3.0)